### PR TITLE
Make GitVersioning recognize submodules

### DIFF
--- a/src/version.json
+++ b/src/version.json
@@ -2,8 +2,7 @@
     // https://github.com/dotnet/Nerdbank.GitVersioning/blob/master/doc/versionJson.md
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
     "pathFilters": [
-        "/directory.build.props",
-        "/StrongName.snk"
+        "/modules"
     ],
     "publicReleaseRefSpec": [
         "^refs/heads/master$"


### PR DESCRIPTION
Nerdbank doesn't seem to recognize changes made to files symlinked from submodules.
Make `version.json` files use `pathFilter` to track the `/modules` directory instead of individual files symlinked from it. 